### PR TITLE
Fix actions by disabling Home class to many attributes

### DIFF
--- a/petsseries/models.py
+++ b/petsseries/models.py
@@ -33,7 +33,7 @@ class User:
 
 
 @dataclass
-class Home:
+class Home:  # pylint: disable=too-many-instance-attributes
     """
     Represents a home associated with a user.
 


### PR DESCRIPTION
This pull request makes a minor update to the `Home` class in `petsseries/models.py`, adding a pylint directive to suppress the "too-many-instance-attributes" warning. This helps keep the code linting clean without requiring a refactor of the class structure.